### PR TITLE
Local coverage reporting

### DIFF
--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -123,7 +123,7 @@
         finally (return (/ (round (* (/ pass all) 10000)) 100.0))))
 
 (defmacro with-coveralls ((&key exclude dry-run (project-dir (project-dir))) &body body)
-  `(if (or ,dry-run (asdf::getenv "COVERALLS"))
+  `(if (asdf::getenv "COVERALLS")
        (report-to-coveralls
         (get-coverage (lambda () ,@body)
                       :exclude ,exclude :project-dir ,project-dir)

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -124,7 +124,7 @@
         sum (count 1 coverage) into pass
         finally (return (/ (round (* (/ pass all) 10000)) 100.0))))
 
-(defmacro with-coveralls ((&key exclude dry-run (project-dir (project-dir))) &body body)
+(defmacro with-coveralls ((&key exclude dry-run (project-dir '(project-dir))) &body body)
   (with-gensyms (reports result)
     `(if (asdf::getenv "COVERALLS")
          (multiple-value-bind (,reports ,result)

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -97,7 +97,7 @@
                                             ((null root-dir) source-path)
                                             ((and (pathname-in-directory-p source-path root-dir)
                                                   (not (find source-path
-                                                             exclude
+                                                             (ensure-list exclude)
                                                              :key (lambda (path)
                                                                     (normalize-exclude-path root-dir path))
                                                              :test (lambda (path1 path2)

--- a/src/impls/sbcl.lisp
+++ b/src/impls/sbcl.lisp
@@ -8,8 +8,7 @@
                 :$
                 :initialize)
   (:import-from :cl-fad
-                :list-directory
-                :delete-directory-and-files)
+                :list-directory)
   (:export :enable-coverage
            :disable-coverage
            :initialize-coverage


### PR DESCRIPTION
Here's a candidate for an implementation of #4. Any suggestions are welcome.
### Example

`[Function] calc-coverage (fn &key project-dir exclude) => coverage-rate`

``` common-lisp
(coveralls:calc-coverage
  (lambda () (prove:run :proc-parse-test))
  :project-dir (asdf:system-source-directory :proc-parse))

...
blah blah blah...
...
...

✓ 15 tests completed (0ms)
87.59
```
