### PR TITLE
Add travis-pro support through the .coveralls.yaml config file.

### DIFF
--- a/cl-coveralls.asd
+++ b/cl-coveralls.asd
@@ -25,7 +25,8 @@
                :cl-ppcre
                :flexi-streams
                :alexandria
-               :split-sequence)
+               :split-sequence
+               :cl-yaclyaml)
   :components ((:module "src"
                 :components
                 ((:file "cl-coveralls" :depends-on ("service" "git" "impls"))


### PR DESCRIPTION
This adds support for private travis builds with the travis-pro service name. This service name is provided in `.coveralls.yaml` as described in [the Travis CI instructions](https://docs.travis-ci.com/user/coveralls/#coveralls-and-private-repositories).