### PR TITLE
Support GitHub Actions!

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,6 +17,8 @@ This software is still ALPHA quality. The APIs will be likely to change.
 
 * [Travis CI](https://travis-ci.org)
 * [CircleCI](https://circleci.com)
+* [GitHub Actions](https://docs.github.com/en/actions), there is also
+  a ready to use action [40ants/run-tests](https://github.com/40ants/run-tests).
 
 ### Number of entered
 

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -87,12 +87,15 @@
                             (pathname out)))
                (retry-handler (dex:retry-request 5 :interval 3)))
            (format t "~&Sending coverage report to Coveralls...~2%~A~%" secure-json)
-           (handler-bind ((dex:http-request-failed (lambda (c)
-                                                     (format t "Server respond with: ~A~%~A~%Retrying~%"
-                                                             (dex:response-status c)
-                                                             (dex:response-body c))
-                                                     (funcall retry-handler
-                                                              c))))
+           (handler-bind ((dex:http-request-failed
+                            (lambda (c)
+                              (let ((headers (alexandria:hash-table-alist (dex:response-headers c))))
+                                (format t "Server respond with: ~A~2%Headers:~%~S~2%Body:~%~A~2%Retrying~%"
+                                        (dex:response-status c)
+                                        headers
+                                        (dex:response-body c)))
+                              (funcall retry-handler
+                                       c))))
              (dex:post "https://coveralls.io/api/v1/jobs"
                        :content `(("json_file" . ,json-file))))))))))
 

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -86,7 +86,7 @@
                             (write-string json out)
                             (pathname out)))
                (retry-handler (dex:retry-request 5 :interval 3)))
-           (format t "~&Sending coverage report to Coveralls...~2%~S~%" secure-json)
+           (format t "~&Sending coverage report to Coveralls...~2%~A~%" secure-json)
            (handler-bind ((dex:http-request-failed (lambda (c)
                                                      (format t "Server respond with: ~A~%~A~%Retrying~%"
                                                              (dex:response-status c)

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -79,7 +79,8 @@
       (cond
         (dry-run
          ;; Here we convert data again
-         (prin1 secure-json))
+         (format t "~A~%"
+                 secure-json))
         (t
          (let ((json-file (uiop:with-temporary-file (:stream out :direction :output :keep t)
                             (write-string json out)

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -51,6 +51,12 @@
                     s))))
 
 
+(defun ensure-string (value)
+  (typecase value
+    (string value)
+    (t (format nil "~A" value))))
+
+
 (defun report-to-coveralls (reports &key dry-run)
   (unless reports
     (return-from report-to-coveralls))
@@ -73,7 +79,11 @@
                     (cons "service_job_id" (service-job-id))
                     (cons "repo_token" repo-token))
               (when-let (pullreq (pull-request-num))
-                (list (cons "service_pull_request" pullreq)))
+                (list (cons "service_pull_request"
+                            ;; API expects this number
+                            ;; to be a string:
+                            ;; https://github.com/lemurheavy/coveralls-public/issues/1527#issuecomment-780812527
+                            (ensure-string pullreq))))
               (list
                (cons "git" (list
                             (cons "head"

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -82,6 +82,20 @@
          (format t "~A~%"
                  secure-json))
         (t
+         (multiple-value-bind (response code headers)
+             (dex:get "https://api.github.com/user"
+                      :headers (list (cons "Authorization"
+                                           (format nil "token ~A"
+                                                   repo-token))))
+           (declare (ignorable code))
+      
+           (let* ((parsed (jonathan:parse response))
+                  (login (getf parsed :|login|))
+                  (scopes (gethash "x-oauth-scopes" headers)))
+             (format t "You are logged in as ~A with following scopes: ~A"
+                     login
+                     scopes)))
+         
          (let ((json-file (uiop:with-temporary-file (:stream out :direction :output :keep t)
                             (write-string json out)
                             (pathname out)))

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -82,6 +82,8 @@
          (format t "~A~%"
                  secure-json))
         (t
+         (format t "Requesting data for ~A~%"
+                 repo-token)
          (multiple-value-bind (response code headers)
              (dex:get "https://api.github.com/user"
                       :headers (list (cons "Authorization"
@@ -92,7 +94,7 @@
            (let* ((parsed (jonathan:parse response))
                   (login (getf parsed :|login|))
                   (scopes (gethash "x-oauth-scopes" headers)))
-             (format t "You are logged in as ~A with following scopes: ~A"
+             (format t "You are logged in as ~A with following scopes: ~A~%"
                      login
                      scopes)))
          

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -70,9 +70,9 @@
                ("source_files" . ,(coerce reports 'simple-vector))))
            (json (jojo:to-json json-data :from :alist)))
       ;; Mask the secret repo token
-      ;; (when (assoc "repo_token" (cdr json-data) :test #'string=)
-      ;;   (rplacd (assoc "repo_token" (cdr json-data) :test #'string=)
-      ;;           "<Secret Coveralls Repo Token>"))
+      (when (assoc "repo_token" (cdr json-data) :test #'string=)
+        (rplacd (assoc "repo_token" (cdr json-data) :test #'string=)
+                "<Secret Coveralls Repo Token>"))
       (cond
         (dry-run
          (prin1 json-data))

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -70,9 +70,9 @@
                ("source_files" . ,(coerce reports 'simple-vector))))
            (json (jojo:to-json json-data :from :alist)))
       ;; Mask the secret repo token
-      (when (assoc "repo_token" (cdr json-data) :test #'string=)
-        (rplacd (assoc "repo_token" (cdr json-data) :test #'string=)
-                "<Secret Coveralls Repo Token>"))
+      ;; (when (assoc "repo_token" (cdr json-data) :test #'string=)
+      ;;   (rplacd (assoc "repo_token" (cdr json-data) :test #'string=)
+      ;;           "<Secret Coveralls Repo Token>"))
       (cond
         (dry-run
          (prin1 json-data))

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -82,22 +82,6 @@
          (format t "~A~%"
                  secure-json))
         (t
-         (format t "Requesting data for ~A~%"
-                 repo-token)
-         (multiple-value-bind (response code headers)
-             (dex:get "https://api.github.com/user"
-                      :headers (list (cons "Authorization"
-                                           (format nil "token ~A"
-                                                   repo-token))))
-           (declare (ignorable code))
-      
-           (let* ((parsed (jonathan:parse response))
-                  (login (getf parsed :|login|))
-                  (scopes (gethash "x-oauth-scopes" headers)))
-             (format t "You are logged in as ~A with following scopes: ~A~%"
-                     login
-                     scopes)))
-         
          (let ((json-file (uiop:with-temporary-file (:stream out :direction :output :keep t)
                             (write-string json out)
                             (pathname out)))
@@ -107,9 +91,8 @@
                                                      (format t "Server respond with: ~A~%~A~%Retrying~%"
                                                              (dex:response-status c)
                                                              (dex:response-body c))
-                                                     ;; (funcall retry-handler
-                                                     ;;          c)
-                                                     )))
+                                                     (funcall retry-handler
+                                                              c))))
              (dex:post "https://coveralls.io/api/v1/jobs"
                        :content `(("json_file" . ,json-file))))))))))
 

--- a/src/cl-coveralls.lisp
+++ b/src/cl-coveralls.lisp
@@ -86,8 +86,9 @@
                                                      (format t "Server respond with: ~A~%~A~%Retrying~%"
                                                              (dex:response-status c)
                                                              (dex:response-body c))
-                                                     (funcall retry-handler
-                                                              c))))
+                                                     ;; (funcall retry-handler
+                                                     ;;          c)
+                                                     )))
              (dex:post "https://coveralls.io/api/v1/jobs"
                        :content `(("json_file" . ,json-file))))))))))
 

--- a/src/git.lisp
+++ b/src/git.lisp
@@ -28,6 +28,7 @@
 
 (defun git-branch ()
   (or (uiop:getenv "GIT_BRANCH")
+      (uiop:getenv "GITHUB_REF")
       (git '("rev-parse" "--abbrev-ref" "HEAD"))))
 
 (defun git-sha ()

--- a/src/git.lisp
+++ b/src/git.lisp
@@ -6,6 +6,7 @@
   (:import-from :alexandria
                 :ends-with-subseq)
   (:export :git-branch
+           :git-sha
            :author-name
            :author-email
            :committer-name
@@ -28,6 +29,9 @@
 (defun git-branch ()
   (or (uiop:getenv "GIT_BRANCH")
       (git '("rev-parse" "--abbrev-ref" "HEAD"))))
+
+(defun git-sha ()
+  (git '("rev-parse" "HEAD")))
 
 (defun author-name ()
   (git '("log" "-1" "--pretty=%aN")))

--- a/src/service.lisp
+++ b/src/service.lisp
@@ -1,43 +1,61 @@
 (in-package :cl-user)
 (defpackage cl-coveralls.service
   (:use :cl)
-  (:import-from :alexandria
-                :when-let)
-  (:export :service-name
-           :service-job-id
-           :project-dir
-           :commit-sha
-           :pull-request-num))
+  (:import-from #:alexandria
+                #:when-let
+                #:when-let*)
+  (:export #:service-name
+           #:service-job-id
+           #:project-dir
+           #:commit-sha
+           #:pull-request-num))
 (in-package :cl-coveralls.service)
 
 (defun service-name ()
   (cond
     ((uiop:getenv "TRAVIS") :travis-ci)
     ((uiop:getenv "CIRCLECI") :circleci)
-    (t :travis-ci)))
+    ((uiop:getenv "GITHUB_ACTIONS") :github)
+    (t :manual)))
 
 (defun service-job-id (&optional (service-name (service-name)))
   (ecase service-name
     (:travis-ci (uiop:getenv "TRAVIS_JOB_ID"))
-    (:circleci (uiop:getenv "CIRCLE_BUILD_NUM"))))
+    (:circleci (uiop:getenv "CIRCLE_BUILD_NUM"))
+    (:github (uiop:getenv "GITHUB_RUN_ID"))
+    (:manual (format nil "~A"
+                     (get-universal-time)))))
 
 (defun project-dir (&optional service-name)
   (case service-name
     (:travis-ci
-     (when-let (travis-build-dir (uiop:getenv "TRAVIS_BUILD_DIR"))
-       (uiop:ensure-directory-pathname travis-build-dir)))
+     (when-let (build-dir (uiop:getenv "TRAVIS_BUILD_DIR"))
+       (uiop:ensure-directory-pathname build-dir)))
     (:circleci
-     (when-let (circleci-build-dir (uiop:getenv "CIRCLE_PROJECT_REPONAME"))
+     (when-let (build-dir (uiop:getenv "CIRCLE_PROJECT_REPONAME"))
        (uiop:ensure-directory-pathname
-        (merge-pathnames circleci-build-dir (user-homedir-pathname)))))
+        (merge-pathnames build-dir (user-homedir-pathname)))))
+    (:github
+     (when-let (build-dir (uiop:getenv "GITHUB_WORKSPACE"))
+       (uiop:ensure-directory-pathname build-dir)))
     (otherwise *default-pathname-defaults*)))
 
 (defun commit-sha (&optional (service-name (service-name)))
   (ecase service-name
     (:travis-ci (uiop:getenv "TRAVIS_COMMIT"))
-    (:circleci (uiop:getenv "CIRCLE_SHA1"))))
+    (:circleci (uiop:getenv "CIRCLE_SHA1"))
+    (:github (uiop:getenv "GITHUB_SHA"))
+    (:manual (uiop:symbol-call :cl-coveralls.git :git-sha))))
 
 (defun pull-request-num (&optional (service-name (service-name)))
   (ecase service-name
     (:travis-ci (uiop:getenv "TRAVIS_PULL_REQUEST"))
-    (:circleci (uiop:getenv "CIRCLE_PR_NUMBER"))))
+    (:circleci (uiop:getenv "CIRCLE_PR_NUMBER"))
+    (:github (when-let* ((event-name (uiop:getenv "GITHUB_EVENT_NAME"))
+                         (event-file (uiop:getenv "GITHUB_EVENT_PATH"))
+                         (file-content (uiop:read-file-string event-file))
+                         (event (jonathan:parse file-content)))
+               ;; This processing taken from official Coveralls GH Action:
+               ;; https://github.com/coverallsapp/github-action/blob/8cbef1dea373ebce56de0a14c68d6267baa10b44/src/run.ts#L38-L40
+               (getf event :|number|)))
+    (:manual nil)))


### PR DESCRIPTION
I was able to use cl-coveralls with this patch to upload report from the GitHub Actions:

https://coveralls.io/builds/37113655

I also created a few Github Actions, to reuse lisp sutup and test running steps. Here is [an example](https://github.com/40ants/cl-info/blob/20810280ccdc86b2e37c26fdb5cef7b026f3623b/.github/workflows/ci.yml#L81-L94) from one of my libraries:

```yaml
    steps:
      - uses: actions/checkout@v1
      - uses: 40ants/setup-lisp@v1
        with:
          asdf-system: cl-info
          qlfile-template: |
            {% ifequal quicklisp_dist "ultralisp" %}
            dist ultralisp http://dist.ultralisp.org
            {% endifequal %}
            github mgl-pax svetlyak40wt/mgl-pax :branch mgl-pax-minimal
            
      - uses: 40ants/run-tests@v2-beta
        with:
          asdf-system: cl-info
          coveralls-token: ${{ secrets.github_token }}
```